### PR TITLE
feat: sync EventSub layer with latest Twitch changes

### DIFF
--- a/eventsub/event.go
+++ b/eventsub/event.go
@@ -970,11 +970,13 @@ type StreamOnlineEvent struct {
 }
 
 type StreamOfflineEvent struct {
-	// The broadcaster’s user id.
+	// The id of the stream.
+	Id string `json:"id"`
+	// The broadcaster's user id.
 	BroadcasterUserId string `json:"broadcaster_user_id"`
-	// The broadcaster’s user login.
+	// The broadcaster's user login.
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
-	// The broadcaster’s user display name.
+	// The broadcaster's user display name.
 	BroadcasterUserName string `json:"broadcaster_user_name"`
 }
 

--- a/eventsub/event.go
+++ b/eventsub/event.go
@@ -196,6 +196,8 @@ type ChannelBitsUseEvent struct {
 	Message *ChannelBitsUseEventMessage `json:"message,omitempty"`
 	// Optional. Data about Power-up.
 	PowerUp *PowerUp `json:"power_up,omitempty"`
+	// Optional. Data about a custom Power-up.
+	CustomPowerUp *ChannelBitsUseCustomPowerUp `json:"custom_power_up,omitempty"`
 }
 
 type ChannelUpdateEvent struct {
@@ -512,6 +514,18 @@ type ChannelChatNotificationEvent struct {
 	// This field has the same information as the announcement field but for a notice that happened for a channel in a shared
 	// chat session other than the broadcaster in the subscription condition.
 	SharedChatAnnouncement *ChatNotificationEventAnnouncementEvent `json:"shared_chat_announcement,omitempty"`
+	// Optional. Whether the notification is only sent to the source channel.
+	// Null if the notification is not in a shared chat session.
+	IsSourceOnly *bool `json:"is_source_only,omitempty"`
+	// Information about the watch streak event. Not presented if notice_type is not watch_streak.
+	WatchStreak *ChatNotificationEventWatchStreakEvent `json:"watch_streak,omitempty"`
+	// Information about the modiversary event. Not presented if notice_type is not modiversary.
+	Modiversary *ChatNotificationEventModiversaryEvent `json:"modiversary,omitempty"`
+	// Information about the shared_chat_modiversary event.
+	// Not presented if notice_type is not shared_chat_modiversary.
+	// This field has the same information as the modiversary field but for a notice that happened for a channel in a shared
+	// chat session other than the broadcaster in the subscription condition.
+	SharedChatModiversary *ChatNotificationEventModiversaryEvent `json:"shared_chat_modiversary,omitempty"`
 }
 
 type ChannelModeratorAddEvent struct {

--- a/eventsub/event.go
+++ b/eventsub/event.go
@@ -336,7 +336,7 @@ type ChannelChatMessageEvent struct {
 	SourceBadges []Badge `json:"source_badges,omitempty"`
 	// Optional. Determines if a message delivered during a shared chat session is only sent to the source channel.
 	// Has no effect if the message is not sent during a shared chat session.
-	IsSourceOnly *bool `json:"is_source_only,omitempty"`
+	IsSourceOnly bool `json:"is_source_only,omitempty"`
 }
 
 type ConduitShardDisabledEvent struct {
@@ -515,8 +515,8 @@ type ChannelChatNotificationEvent struct {
 	// chat session other than the broadcaster in the subscription condition.
 	SharedChatAnnouncement *ChatNotificationEventAnnouncementEvent `json:"shared_chat_announcement,omitempty"`
 	// Optional. Whether the notification is only sent to the source channel.
-	// Null if the notification is not in a shared chat session.
-	IsSourceOnly *bool `json:"is_source_only,omitempty"`
+	// False if the notification is not in a shared chat session.
+	IsSourceOnly bool `json:"is_source_only,omitempty"`
 	// Information about the watch streak event. Not presented if notice_type is not watch_streak.
 	WatchStreak *ChatNotificationEventWatchStreakEvent `json:"watch_streak,omitempty"`
 	// Information about the modiversary event. Not presented if notice_type is not modiversary.

--- a/eventsub/object.go
+++ b/eventsub/object.go
@@ -223,8 +223,9 @@ type BlockedTerm struct {
 type BitsUseType string
 
 const (
-	BitsUseCheer   BitsUseType = "cheer"
-	BitsUsePowerUp BitsUseType = "power_up"
+	BitsUseCheer         BitsUseType = "cheer"
+	BitsUsePowerUp       BitsUseType = "power_up"
+	BitsUseCustomPowerUp BitsUseType = "custom_power_up"
 )
 
 type BitsPowerUpType string
@@ -239,6 +240,13 @@ type PowerUp struct {
 	Type            BitsPowerUpType `json:"type"`
 	Emote           *RewardEmote    `json:"emote,omitempty"`
 	MessageEffectId string          `json:"message_effect_id,omitempty"`
+}
+
+type ChannelBitsUseCustomPowerUp struct {
+	// The title of the custom Power-up.
+	Title string `json:"title"`
+	// The ID of the custom Power-up.
+	RewardId string `json:"reward_id"`
 }
 
 type MessageType string
@@ -481,6 +489,20 @@ type ChatNotificationEventBitsBadgeTierEvent struct {
 	Tier int `json:"tier"`
 }
 
+// ChatNotificationEventWatchStreakEvent represents information about the watch streak event.
+type ChatNotificationEventWatchStreakEvent struct {
+	// The number of consecutive broadcasts for which the user has been watching.
+	StreakCount int `json:"streak_count"`
+	// The number of channel points awarded for the Watch Streak milestone.
+	ChannelPointsAwarded int `json:"channel_points_awarded"`
+}
+
+// ChatNotificationEventModiversaryEvent represents information about the modiversary event.
+type ChatNotificationEventModiversaryEvent struct {
+	// The number of months the user has been a moderator in this channel.
+	Months int `json:"months"`
+}
+
 type ChatNotificationEventNoticeType string
 
 const (
@@ -496,6 +518,8 @@ const (
 	ChatNotificationEventNoticeTypeAnnouncement               ChatNotificationEventNoticeType = "announcement"
 	ChatNotificationEventNoticeTypeBitsBadgeTier              ChatNotificationEventNoticeType = "bits_badge_tier"
 	ChatNotificationEventNoticeTypeCharityDonation            ChatNotificationEventNoticeType = "charity_donation"
+	ChatNotificationEventNoticeTypeWatchStreak                ChatNotificationEventNoticeType = "watch_streak"
+	ChatNotificationEventNoticeTypeModiversary                ChatNotificationEventNoticeType = "modiversary"
 	ChatNotificationEventNoticeTypeSharedChatSub              ChatNotificationEventNoticeType = "shared_chat_sub"
 	ChatNotificationEventNoticeTypeSharedChatReSub            ChatNotificationEventNoticeType = "shared_chat_resub"
 	ChatNotificationEventNoticeTypeSharedChatSubGift          ChatNotificationEventNoticeType = "shared_chat_sub_gift"
@@ -505,6 +529,8 @@ const (
 	ChatNotificationEventNoticeTypeSharedChatRaid             ChatNotificationEventNoticeType = "shared_chat_raid"
 	ChatNotificationEventNoticeTypeSharedChatPayItForward     ChatNotificationEventNoticeType = "shared_chat_pay_it_forward"
 	ChatNotificationEventNoticeTypeSharedChatAnnouncement     ChatNotificationEventNoticeType = "shared_chat_announcement"
+	ChatNotificationEventNoticeTypeSharedChatModiversary      ChatNotificationEventNoticeType = "shared_chat_modiversary"
+	ChatNotificationEventNoticeTypeUnknown                    ChatNotificationEventNoticeType = "unknown"
 )
 
 func (c ChatNotificationEventNoticeType) String() string {

--- a/eventsub/object.go
+++ b/eventsub/object.go
@@ -40,6 +40,7 @@ const (
 	MessageFragmentEmote     MessageFragmentType = "emote"
 	MessageFragmentCheermote MessageFragmentType = "cheermote"
 	MessageFragmentMention   MessageFragmentType = "mention"
+	MessageFragmentGif       MessageFragmentType = "gif"
 )
 
 type Mention struct {
@@ -170,6 +171,14 @@ type ChannelChatMessageEventMessageFragment struct {
 	Emote     *ChannelChatMessageEventMessageEmote `json:"emote,omitempty"`
 	Cheermote *Cheermote                           `json:"cheermote,omitempty"`
 	Mention   *Mention                             `json:"mention"`
+	Gif       *ChannelChatMessageEventMessageGif   `json:"gif,omitempty"`
+}
+
+type ChannelChatMessageEventMessageGif struct {
+	// GifId is an ID that uniquely identifies this GIF.
+	GifId string `json:"gif_id"`
+	// URL is the URL of the GIF asset. Applications rendering the GIF must use the full URL provided; it must not be modified.
+	URL string `json:"url"`
 }
 
 type ChannelChatMessageEventMessageEmote struct {


### PR DESCRIPTION
Brings the EventSub layer up to date with the current [Twitch changelog](https://dev.twitch.tv/docs/change-log) and reference docs.

**channel.chat.message — gif fragment (2026-07-16)**

GIF messages now include a `gif` object on the message fragment with `gif_id` and `url` fields alongside the existing `text`:

```json
{
  "type": "gif",
  "text": "excited",
  "gif": {
    "gif_id": "1234",
    "url": "https://static-cdn.jtvnw.net/gif/1234.gif"
  }
}
```

- New `MessageFragmentGif` (`"gif"`) value of `MessageFragmentType`.
- New `ChannelChatMessageEventMessageGif` struct with `gif_id` and `url` fields.
- New optional `Gif` field on `ChannelChatMessageEventMessageFragment`.

**stream.offline — id field (2026-06-26)**

- New `Id` field on `StreamOfflineEvent`, matching `stream.online`.

**channel.chat.notification — new notice types and fields (2026-04-02, 2026-06-08, 2026-06-12)**

- New `ChatNotificationEventNoticeType` values: `watch_streak`, `modiversary`, `shared_chat_modiversary`, `unknown`.
- New `ChatNotificationEventWatchStreakEvent` struct (`streak_count`, `channel_points_awarded`).
- New `ChatNotificationEventModiversaryEvent` struct (`months`).
- New fields on `ChannelChatNotificationEvent`: `WatchStreak`, `Modiversary`, `SharedChatModiversary`, `IsSourceOnly`.

**channel.bits.use — custom Power-ups (2026-04-02)**

- New `BitsUseCustomPowerUp` (`"custom_power_up"`) value of `BitsUseType`.
- New `ChannelBitsUseCustomPowerUp` struct (`title`, `reward_id`).
- New optional `CustomPowerUp` field on `ChannelBitsUseEvent`.

Verified against the [EventSub reference](https://dev.twitch.tv/docs/eventsub/eventsub-reference/): `channel.moderate` v2, `channel.chat.message` and the hype train events already match the current docs.