### PR TITLE
fix(helix): accept app access tokens for SendChatMessage and SendChatAnnouncement

### DIFF
--- a/helix/chat_auth_test.go
+++ b/helix/chat_auth_test.go
@@ -34,14 +34,6 @@ func TestChatAuthorizationRejectsUnsupportedCredentialsBeforeNetwork(t *testing.
 			},
 		},
 		{
-			name:       "announcement app missing channel bot",
-			credential: chatCredential(helix.TokenClassApp, "", helix.ScopeModeratorManageAnnouncements, helix.ScopeUserBot),
-			call: func(client *helix.Client) error {
-				_, err := client.Chat.SendChatAnnouncement(context.Background(), helix.SendChatAnnouncementRequest{BroadcasterID: "1234", ModeratorID: "5678", Message: "hello"})
-				return err
-			},
-		},
-		{
 			name:       "user announcement for source only is forbidden",
 			credential: chatCredential(helix.TokenClassUser, "5678", helix.ScopeModeratorManageAnnouncements),
 			call: func(client *helix.Client) error {

--- a/helix/chat_messages.go
+++ b/helix/chat_messages.go
@@ -98,8 +98,10 @@ func (s *ChatService) SendChatAnnouncement(ctx context.Context, req SendChatAnno
 		query:  req,
 		body:   req,
 		auth: chatAuthorization{
+			// App access tokens carry no scopes: Twitch authorizes them through the
+			// moderator's moderator:manage:announcements + user:bot grants and the
+			// broadcaster's channel:bot grant, so there is nothing to check locally.
 			userScopeSets:           chatReadScopes(ScopeModeratorManageAnnouncements),
-			appScopeSets:            chatBotScopes(ScopeModeratorManageAnnouncements),
 			subjectID:               req.ModeratorID,
 			rejectForSourceOnlyUser: req.ForSourceOnly != nil,
 		},
@@ -122,13 +124,8 @@ func (s *ChatService) SendShoutout(ctx context.Context, req SendShoutoutRequest)
 
 func (s *ChatService) SendChatMessage(ctx context.Context, req SendChatMessageRequest) (*Response[SendChatMessageData], error) {
 	userScopeSets := chatReadScopes(ScopeUserWriteChat)
-	appScopeSets := [][]AuthorizationScope{{ScopeUserWriteChat, ScopeUserBot}, {ScopeUserWriteChat, ScopeUserBot, ScopeChannelBot}}
 	if req.Pin != nil && *req.Pin {
 		userScopeSets = [][]AuthorizationScope{{ScopeUserWriteChat, ScopeModeratorManageChatMessages}}
-		appScopeSets = [][]AuthorizationScope{
-			{ScopeUserWriteChat, ScopeModeratorManageChatMessages, ScopeUserBot},
-			{ScopeUserWriteChat, ScopeModeratorManageChatMessages, ScopeUserBot, ScopeChannelBot},
-		}
 	}
 	return executeChatEndpoint[SendChatMessageData](chatEndpointSpec{
 		client: s.client,
@@ -136,8 +133,10 @@ func (s *ChatService) SendChatMessage(ctx context.Context, req SendChatMessageRe
 		anchor: "send-chat-message",
 		body:   req,
 		auth: chatAuthorization{
+			// App access tokens carry no scopes: Twitch authorizes them through the
+			// sender's user:write:chat + user:bot grants and the broadcaster's
+			// channel:bot grant, so there is nothing to check locally.
 			userScopeSets:           userScopeSets,
-			appScopeSets:            appScopeSets,
 			subjectID:               req.SenderID,
 			rejectForSourceOnlyUser: req.ForSourceOnly != nil,
 		},

--- a/helix/chat_stable_operations_test.go
+++ b/helix/chat_stable_operations_test.go
@@ -142,6 +142,36 @@ func TestChatStableOperations(t *testing.T) {
 	}
 }
 
+func TestChatSendChatMessageAllowsScopelessAppToken(t *testing.T) {
+	// Given a message request authorized by a scope-less app access token.
+	testCase := chatOperationCase{
+		anchor:     "send-chat-message",
+		fixture:    chatRequestBodyFixture(chatSuccessFixture(urlValues(), http.StatusOK, `{"data":[{"message_id":"message-1","is_sent":true}]}`), `{"broadcaster_id":"1234","sender_id":"5678","message":"hello"}`),
+		credential: chatCredential(helix.TokenClassApp, ""),
+		call: func(client *helix.Client) (helix.ResponseMeta, error) {
+			return chatMeta(client.Chat.SendChatMessage(context.Background(), helix.SendChatMessageRequest{BroadcasterID: "1234", SenderID: "5678", Message: "hello"}))
+		},
+	}
+
+	// When the message is sent.
+	runChatOperation(t, testCase)
+}
+
+func TestChatSendChatAnnouncementAllowsScopelessAppToken(t *testing.T) {
+	// Given an announcement request authorized by a scope-less app access token.
+	testCase := chatOperationCase{
+		anchor:     "send-chat-announcement",
+		fixture:    chatRequestBodyFixture(chatSuccessFixture(urlValues("broadcaster_id", "1234", "moderator_id", "5678"), http.StatusNoContent, ""), `{"message":"hello"}`),
+		credential: chatCredential(helix.TokenClassApp, ""),
+		call: func(client *helix.Client) (helix.ResponseMeta, error) {
+			return chatMeta(client.Chat.SendChatAnnouncement(context.Background(), helix.SendChatAnnouncementRequest{BroadcasterID: "1234", ModeratorID: "5678", Message: "hello"}))
+		},
+	}
+
+	// When the announcement is sent.
+	runChatOperation(t, testCase)
+}
+
 func TestChatSendChatMessageOmitsUnsetSourceAndPin(t *testing.T) {
 	// Given a message request without the optional source or pin flags.
 	testCase := chatOperationCase{


### PR DESCRIPTION
## Problem

`Chat.SendChatMessage` and `Chat.SendChatAnnouncement` rejected app access tokens locally with `credential rejected by local authorization constraints`, forcing callers to use a bot user token instead.

The local check compared the endpoint's required scopes against the scopes attached to the token snapshot. App access tokens carry **no scopes**, so the check could never pass for a real app token.

## What Twitch actually documents

Both endpoints accept app access tokens, authorized server-side through **prior grants**, not token scopes:

- [Send Chat Message](https://dev.twitch.tv/docs/api/reference/#send-chat-message): the app must have `user:write:chat` + `user:bot` for `sender_id`, and `channel:bot` for `broadcaster_id` (unless the sender is already a moderator). `pin=true` additionally requires `moderator:manage:chat_messages`.
- [Send Chat Announcement](https://dev.twitch.tv/docs/api/reference/#send-chat-announcement): the app must have `moderator:manage:announcements` + `user:bot` for `moderator_id`, and `channel:bot` for `broadcaster_id`.

These grants are not observable from the client, so a local scope check on app tokens is unsound in both directions: it rejects valid tokens (no scopes attached) and cannot actually confirm the grants exist.

## Change

- Dropped the app-token scope-set requirement for `send-chat-message` and `send-chat-announcement`; any app access token now reaches the network and Twitch answers 401 if the grants are missing. User-token validation (scopes, `subjectID`, `for_source_only` rejection) is unchanged.
- Removed the now-obsolete `announcement app missing channel bot` local-rejection test case.
- Added wire-contract tests proving scope-less app tokens send both messages and announcements.

## Verification

- `go test ./... -count=1` — all packages pass.
- `go test ./helix/ -v -run 'AllowsScopelessAppToken'` — both new contract tests pass.